### PR TITLE
Fix model list

### DIFF
--- a/src/app/App.js
+++ b/src/app/App.js
@@ -42,7 +42,11 @@ class App extends Component {
     return (
       <div className={style.appContainer}>
         <div className={style.header}>
-          <Menu inverted pointing secondary size='large'>
+          <Menu
+            inverted
+            pointing
+            secondary
+            size='large'>
             {pages.map(page => {
               return (
                 <Link key={page.name} to={page.link}>

--- a/src/app/App.scss
+++ b/src/app/App.scss
@@ -7,4 +7,9 @@
   background-color: #17181b;
   opacity: 0.97;
   box-shadow: 0px 6px 8px -4px rgba(0,0,0,0.9);
+  z-index: 50;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
 }

--- a/src/manga/MangaPage.js
+++ b/src/manga/MangaPage.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 // import styles from './MangaPage.scss
 import ThumbnailPage from '../shared/ThumbnailPage';
 import { getModelData } from '../shared/Requests';
+import getStartYear from '../shared/GetStartYear';
 
 class MangaPage extends Component {
 
@@ -23,8 +24,8 @@ class MangaPage extends Component {
         data={this.state.data.map(manga => {
           return {
             ...manga,
-            subInfo_1: `${manga.year}`,
-            subInfo_2: manga.num_chapters,
+            subInfo_1: `${getStartYear(manga.published)}`,
+            subInfo_2: `${manga.num_chapters} chapters`,
           }
         })} />
     );

--- a/src/shared/GetStartYear.js
+++ b/src/shared/GetStartYear.js
@@ -1,0 +1,7 @@
+
+export default function getStartYear (dateString) {
+  const regex = /(?:(?:19|20)[0-9]{2})/;
+  const aired = dateString ? dateString.match(regex) : [];
+  const year = aired ? aired[0] : "";
+  return year;
+}

--- a/src/shared/ThumbnailCard.js
+++ b/src/shared/ThumbnailCard.js
@@ -11,7 +11,6 @@ class ThumbnailCard extends Component {
 
   render() {
     const { active } = this.state
-    const unitName = this.props.isManga ? "chapters" : "chapters"
     return (
       <div className={styles.container} onMouseEnter={this.handleShow} onMouseLeave={this.handleHide}>
         <Dimmer.Dimmable dimmed={active}>
@@ -21,19 +20,18 @@ class ThumbnailCard extends Component {
           <Image
             width="134px"
             height="196px"
+            shape="rounded"
             src={this.props.picture} />
         </Dimmer.Dimmable>
         <div className={styles.title}>
-          <div>
-            {this.props.title}
-          </div>
+          {this.props.title}
         </div>
         <div className={styles.subInfo}>
           <div>
             {this.props.subInfo_1}
           </div>
           <div>
-            {this.props.subInfo_2 ? `${this.props.subInfo_2} ${unitName}` : null}
+            {this.props.subInfo_2 || null}
           </div>
         </div>
       </div>
@@ -45,7 +43,7 @@ ThumbnailCard.propTypes = {
   title: PropTypes.string,
   picture: PropTypes.string,
   subInfo_1: PropTypes.string,
-  subInfo_2: PropTypes.number,
+  subInfo_2: PropTypes.string,
   isManga: PropTypes.bool,
 }
 

--- a/src/shared/ThumbnailCard.scss
+++ b/src/shared/ThumbnailCard.scss
@@ -13,6 +13,11 @@
   margin-top: 6px;
   margin-bottom: 0px;
   color: #fff;
+  max-width: 100%;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .subInfo {

--- a/src/shared/ThumbnailPage.scss
+++ b/src/shared/ThumbnailPage.scss
@@ -1,11 +1,18 @@
 .container {
-  width: 100%;
   height: 100%;
+  width: 100%;
+  padding: 10px;
+  padding-top: 50px;
   background-color: #17181b;
-  padding-top: 10px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  overflow-x: hidden;
+  overflow-y: overlay;
   display: flex;
+  flex-direction: row;
   flex-wrap: wrap;
-  justify-content: flex-start;
+  justify-content: space-between;
   align-content: flex-start;
 }
 

--- a/src/shows/ShowsPage.js
+++ b/src/shows/ShowsPage.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 // import styles from './ShowsPage.scss';
 import ThumbnailPage from '../shared/ThumbnailPage';
 import { getModelData } from '../shared/Requests';
+import getStartYear from '../shared/GetStartYear';
 
 class ShowsPage extends Component {
 
@@ -23,8 +24,8 @@ class ShowsPage extends Component {
         data={this.state.data.map(show => {
           return {
             ...show,
-            subInfo_1: `${show.year}`,
-            subInfo_2: show.num_episodes,
+            subInfo_1: `${getStartYear(show.aired)}`,
+            subInfo_2: `${show.num_episodes} episodes`,
           }
         })} />
     );


### PR DESCRIPTION
This pull request does a few clean-up things.

1. Centers the list of models on the model pages to that they have a consistent amount of space on the left and right of them

2. Rounds the corners of the images so they are more pleasing to the eye

3. Some titles where too long, so css has been added to cut them short with a '...' if needed

4. Fixed undefined start dates for manga and anime

5. Fixes the position of the menu to the top of the website

6. Scrolling on the model pages now behaves correctly. The top nav menu is slightly transparent so there is a cool effect of scrolling the models under it