### PR TITLE
Cleaned up a few issues with the modal

### DIFF
--- a/src/modal/ModalContent.js
+++ b/src/modal/ModalContent.js
@@ -9,6 +9,7 @@ import MangaModalContent from '../manga/MangaModalContent';
 import { getSingleModel } from '../shared/Requests';
 import defaultImage from '../shared/DefaultImage';
 import { changeModalURL } from '../shared/Utilities';
+import { Loader } from 'semantic-ui-react';
 
 class ModalContent extends Component {
 
@@ -25,7 +26,10 @@ class ModalContent extends Component {
   }
 
   componentWillReceiveProps = (nextProps) => {
-    this.getModelData(nextProps.type, nextProps.id);
+    if (nextProps.id !== this.props.id || nextProps.type !== this.props.type) {
+      this.setState({dataObject: null});
+      this.getModelData(nextProps.type, nextProps.id);
+    }
   }
 
   getModelData = (type, id) => {
@@ -56,7 +60,16 @@ class ModalContent extends Component {
 
   render() {
     if (!this.state.dataObject) {
-      return <div className={styles.container}></div>
+      return (
+        <div className={styles.container}>
+          <Loader
+            size="massive"
+            active
+            inverted>
+            Loading
+          </Loader>
+        </div>
+      );
     }
     return (
       <div className={styles.container}>

--- a/src/modal/ModalDetails.scss
+++ b/src/modal/ModalDetails.scss
@@ -6,11 +6,16 @@
 }
 
 .titleText {
-  font-size: 60px;
-  color: white;
   &:hover {
     color: white;
   }
+  font-size: 60px;
+  color: white;
+  max-width: 100%;
+  display: block;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
 .bullet {
@@ -18,9 +23,11 @@
 }
 
 .info {
-  height: 70%;
-  max-height: 70%;
+  flex: 1 1 100%;
   color: white;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
 }
 
 .vid {
@@ -47,13 +54,13 @@
 }
 
 .paragraph {
+  flex: 1 1 40%;
   line-height: 21px;
-  height: 30%;
-  max-height: 30%;
   overflow: auto;
 }
 
 .head {
+  flex: 0 0 auto;
   display: block;
   overflow: auto; 
   width: 100%;
@@ -61,13 +68,14 @@
 }
 
 .divider {
+  flex: 0 0 auto;
   width: 95%;
   margin: auto;
   border-top: 1px solid rgba(255, 255, 255, .3);
 }
 
 .listsContainer {
-  height: 70%;
+  flex: 1 1 60%;
   width: 100%;
   display: flex;
   flex-direction: row;
@@ -76,6 +84,8 @@
 .content {
   width: 100%;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 }
 
 .tabs {

--- a/src/modal/ScrollableList.js
+++ b/src/modal/ScrollableList.js
@@ -31,6 +31,7 @@ class ModalContent extends Component {
               <div
                 key={element.name}
                 onClick={() => this.props.action(element.index)}
+                className={styles.element}
                 style={{backgroundColor: color}}>
                 <div className={styles.innerElement}>
                   {element.name}

--- a/src/modal/ScrollableList.scss
+++ b/src/modal/ScrollableList.scss
@@ -20,10 +20,12 @@
 	overflow: auto;
 }
 
-.innerElement {
-	background-color: transparent;
-	padding: 20px;
+.element {
 	margin: 3px;
+}
+
+.innerElement {
+	padding: 20px;
 	font-size: 20px;
 	cursor: pointer;
 	color: white;


### PR DESCRIPTION
1. Cut off long titles with the '...'

2. Added a loader component that is visible while the content is loading

3. I changed some of the css to use flex-box to fill the whole modal height. This part was a little difficult, but it seems to be working. I set the paragraph to take up 40% of the available height and the scrollable lists to take up 60% of the available height.

4. Fixed the issue where highlighting in the scrollable lists wasn't the same width as the colored background.